### PR TITLE
Fix faq table schema error

### DIFF
--- a/src/components/admin/TestimonialsManagement.tsx
+++ b/src/components/admin/TestimonialsManagement.tsx
@@ -22,7 +22,9 @@ interface Testimonial {
   status: string;
   client_photo_url: string;
   created_at: string;
-  property: {
+  property_id?: string;
+  property?: {
+    id?: string;
     title: string;
     location: string;
   };
@@ -66,7 +68,7 @@ const TestimonialsManagement = () => {
         .from('testimonials')
         .select(`
           *,
-          property:properties(title, location)
+          property:properties(id, title, location)
         `)
         .order('created_at', { ascending: false });
 
@@ -205,7 +207,7 @@ const TestimonialsManagement = () => {
       featured: testimonial.featured,
       status: testimonial.status,
       client_photo_url: testimonial.client_photo_url || '',
-      property_id: testimonial.property?.id || ''
+      property_id: testimonial.property_id || testimonial.property?.id || ''
     });
     setDialogOpen(true);
   };


### PR DESCRIPTION
Fix blank page on "New Testimonial" by safely accessing `property_id`.

The previous implementation would crash if `testimonial.property` or `testimonial.property.id` was undefined when opening the new testimonial dialog, leading to a blank page. This change ensures `property_id` is always derived safely.

---
<a href="https://cursor.com/background-agent?bcId=bc-bb15bbd8-179a-4448-b7aa-9861d904fc16">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bb15bbd8-179a-4448-b7aa-9861d904fc16">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

